### PR TITLE
New dial query command

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"errors"
+	"fmt"
 	"math"
 	"net/http"
 	"strconv"
@@ -326,7 +327,32 @@ func (a *ooohhAPI) slackCommand() http.Handler {
 		if t == "help" {
 			api.Respond(w, r, http.StatusOK, response{
 				Type: "ephemeral",
-				Text: "Use the following format to set a value: `/wtf value`",
+				Text: "Use the following format to set a value: `/wtf <number>`",
+			})
+			return
+		}
+
+		// Query for value.
+		if t == "?" {
+			d, err := a.ss.GetDial(r.Context(), body.TeamID, body.UserID)
+			if err != nil {
+
+				// Calculate the response text based on the error value.
+				text := "Oops, something didn't quite work out. Please, try again."
+				if errors.Is(err, slack.ErrDialNotFound) {
+					text = "Use the following format to set a value: `/wtf <number>`"
+				}
+
+				api.Respond(w, r, http.StatusOK, response{
+					Type: "ephemeral",
+					Text: text,
+				})
+				return
+			}
+
+			api.Respond(w, r, http.StatusOK, response{
+				Type: "ephemeral",
+				Text: fmt.Sprintf("Your dial (%s) is set to %.1f.", d.ID, d.Value),
 			})
 			return
 		}

--- a/pkg/mock/mock.go
+++ b/pkg/mock/mock.go
@@ -81,10 +81,19 @@ func (s *Service) Reset() {
 type SlackService struct {
 	SetDialValueFn      func(ctx context.Context, teamID, userID string, value float64) error
 	SetDialValueInvoked bool
+
+	GetDialFn      func(ctx context.Context, teamID, userID string) (*ooohh.Dial, error)
+	GetDialInvoked bool
 }
 
 // SetDialValue updates the given user's dial value.
 func (s *SlackService) SetDialValue(ctx context.Context, teamID string, userID string, value float64) error {
 	s.SetDialValueInvoked = true
 	return s.SetDialValueFn(ctx, teamID, userID, value)
+}
+
+// GetDial returns the dial for the given user.
+func (s *SlackService) GetDial(ctx context.Context, teamID, userID string) (*ooohh.Dial, error) {
+	s.GetDialInvoked = true
+	return s.GetDialFn(ctx, teamID, userID)
 }


### PR DESCRIPTION
A new slack option to return your current dial value, and it's ID (e.g. for sharing).

Used like so: `/wtf ?`.

Responds with: `Your dial (<id>) is set to <value>.`